### PR TITLE
Various Portability Improvements & Fixes

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # dot
 #
@@ -7,7 +7,7 @@
 
 set -e
 
-parentDirectory="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+parentDirectory="$(cd "$( dirname "${BASH_SOURCE[0]:-$0}" )" && pwd -P)"
 dotfilesDirectory="$(cd "$( dirname "$parentDirectory" )" && pwd -P)"
 
 displayUsageAndExit() {
@@ -38,7 +38,7 @@ while test $# -gt 0; do
 	shift
 done
 
-export DOTFILES_ROOT=$HOME/.dotfiles
+export DOTFILES_ROOT=$dotfilesDirectory
 
 # Set macOS defaults
 $DOTFILES_ROOT/macos/set-defaults.sh

--- a/go/install.sh
+++ b/go/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # goenv
 #

--- a/macos/set-defaults.sh
+++ b/macos/set-defaults.sh
@@ -7,6 +7,12 @@
 #
 # Run ./set-defaults.sh and you'll be good to go.
 
+# exit the script if not running on a mac
+if test ! "$(uname)" = "Darwin"
+  then
+  exit 0
+fi
+
 # Always open everything in Finder's list view. This is important.
 defaults write com.apple.Finder FXPreferredViewStyle Nlsv
 

--- a/node/env.zsh
+++ b/node/env.zsh
@@ -17,6 +17,9 @@ if test "$(command -v nvm)"; then
                 nvm use
             fi
         elif [ "$node_version" != "$(nvm version default)" ]; then
+            if [ "$(nvm version default)" = "N/A" ]; then
+                nvm install --lts
+            fi
             echo "Reverting to nvm default version"
             nvm use default
         fi

--- a/python/completion.zsh
+++ b/python/completion.zsh
@@ -1,6 +1,12 @@
 
 # enable pipx completion
 if test "$(which pipx)"; then
+    if ! pip3 list 2&> /dev/null | grep -q argcomplete; then
+        pip3 install argcomplete
+    fi
+
+    autoload -U bashcompinit
+    bashcompinit
     eval "$(register-python-argcomplete pipx)"
 fi
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,8 +2,9 @@
 #
 # bootstrap installs things.
 
-cd "$(dirname "$0")/.."
-DOTFILES_ROOT=$(pwd -P)
+parentDirectory="$(cd "$( dirname "${BASH_SOURCE[0]:-$0}" )" && pwd -P)"
+dotfilesDirectory="$(cd "$( dirname "$parentDirectory" )" && pwd -P)"
+DOTFILES_ROOT=$dotfilesDirectory
 
 set -e
 

--- a/system/install.sh
+++ b/system/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# if not previously installed this script will install coreutils using brew
+
+
+if ! $(brew list | grep -q "coreutils"); then
+    echo "Installing coreutils"
+    brew install coreutils
+fi

--- a/system/path.zsh
+++ b/system/path.zsh
@@ -1,0 +1,2 @@
+export DOTFILES_BIN="$DOTFILES_ROOT/bin"
+export PATH="$DOTFILES_BIN:$PATH"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -24,7 +24,12 @@ fi
 
 # all of our zsh files
 typeset -U config_files
-config_files=("$DOTFILES_ROOT"/**/*.zsh "$PRIVATE_DOTFILES_ROOT"/**/*.zsh)
+config_files=("$DOTFILES_ROOT"/**/*.zsh)
+
+# add private dot files only if the directory exists
+if [[ -d "$PRIVATE_DOTFILES_ROOT" ]]; then
+  config_files+=("$PRIVATE_DOTFILES_ROOT"/**/*.zsh)
+fi
 
 # load the path files
 for file in ${(M)config_files:#*/path.zsh}; do

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+# determine dotfiles root by following the symlinked file (syntax dependent on shell)
+if [[ $(basename "${BASH_SOURCE[0]:-$0}") =  "zsh" ]]; then
+    parentDirectory="$(cd "$( dirname "$( readlink -f "${(%):-%N}" )" )" && pwd -P)"
+  else
+    parentDirectory="$(cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]:-$0}" )" )" && pwd -P)"
+fi
+dotfilesDirectory="$(cd "$( dirname "$parentDirectory" )" && pwd -P)"
 # shortcut to this dotfiles path is $DOTFILES_ROOT
-export DOTFILES_ROOT=$HOME/.dotfiles
+export DOTFILES_ROOT=$dotfilesDirectory
 export PRIVATE_DOTFILES_ROOT=$HOME/.private_dotfiles
 
 # your project folders that we can `c [tab]` to

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -53,25 +53,6 @@ done
 unset config_files
 
 
-# all of our custom shell commands
-typeset -U custom_shell_cmds
-custom_shell_cmds=("$DOTFILES_ROOT"/bin/*)
-if [[ -d  "$PRIVATE_DOTFILES_ROOT"/bin ]]; then
-  custom_shell_cmds+=("$PRIVATE_DOTFILES_ROOT"/bin/*)
-fi
-
-# symlink shell script commands from bin dirs to /usr/local/bin
-for file in ${custom_shell_cmds}; do
-  file_name=${file##*/}
-  symlink=/usr/local/bin/"$file_name"
-  if [[ ! -h "$symlink" ]]; then
-    ln -s "$file" "$symlink"
-  fi
-done
-
-unset custom_shell_cmds
-
-
 # Better history
 # Credits to https://coderwall.com/p/jpj_6q/zsh-better-history-searching-with-arrow-keys
 autoload -U up-line-or-beginning-search


### PR DESCRIPTION
- fix the `go` installer syntax error by updating the shell script type to `#!/bin/bash`
- only execute `mac`-specific commands if run on a mac
- fix `nvm` warning when no `node` is installed by... installing latest lts (long-term support) `node` release if none is installed
- update all `DOTFILES_ROOT` environment variable assignments to a dynamically determined location of the `.dotfiles` repo's root (AKA we don't assume that the `.dotfiles` repo was cloned into the home directory of the user anymore)
- fixes the sourcing of configuration files to only try to source private dotfiles if private dotfiles directory exists
- adds the `bin` directory of the `.dotfiles` repo to the `PATH` instead of trying to symlink those commands into the `/usr/local/bin` directory since it's possible the user doesn't have permissions to create files in that directory
- installs `coreutils` if not present