### PR TITLE
Codespaces Compatibility Fixes

### DIFF
--- a/go/env.zsh
+++ b/go/env.zsh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 
-if test "$(which goenv)"; then
+if (( $+commands[goenv] )); then
   eval "$(goenv init -)"
 fi

--- a/node/env.zsh
+++ b/node/env.zsh
@@ -18,7 +18,7 @@ if test "$(command -v nvm)"; then
             fi
         elif [ "$node_version" != "$(nvm version default)" ]; then
             if [ "$(nvm version default)" = "N/A" ]; then
-                nvm install --lts
+                nvm install --lts --default
             fi
             echo "Reverting to nvm default version"
             nvm use default

--- a/python/completion.zsh
+++ b/python/completion.zsh
@@ -22,7 +22,7 @@ if (( $+commands[pdm] )); then
   # Otherwise, source it and regenerate in the background
   if [[ ! -f "$ZSH_CACHE_DIR/completions/_pdm" ]]; then
     pdm completion zsh >| "$ZSH_CACHE_DIR/completions/_pdm"
-    autload -U "$ZSH_CACHE_DIR/completions/_pdm"
+    autoload -U "$ZSH_CACHE_DIR/completions/_pdm"
   else
     unfunction _pdm
     autoload -U "$ZSH_CACHE_DIR/completions/_pdm"

--- a/python/env.zsh
+++ b/python/env.zsh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if test "$(which pyenv)"; then
+if (( $+commands[pyenv] )); then
   # Configure the shell environment for pyenv
   eval "$(pyenv init - --no-rehash zsh)"
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -29,24 +29,28 @@ fail () {
 }
 
 setup_gitconfig () {
-  if ! [ -f git/gitconfig.local.symlink ]
-  then
-    info 'setup gitconfig'
-
-    git_credential='cache'
-    if [ "$(uname -s)" == "Darwin" ]
+  if [[ -o interactive ]]; then
+    if ! [ -f git/gitconfig.local.symlink ]
     then
-      git_credential='osxkeychain'
+      info 'setup gitconfig'
+
+      git_credential='cache'
+      if [ "$(uname -s)" == "Darwin" ]
+      then
+        git_credential='osxkeychain'
+      fi
+
+      user ' - What is your github author name?'
+      read -e git_authorname
+      user ' - What is your github author email?'
+      read -e git_authoremail
+
+      sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" "$DOTFILES_ROOT"/git/gitconfig.local.symlink.example > "$DOTFILES_ROOT"/git/gitconfig.local.symlink
+
+      success 'gitconfig'
     fi
-
-    user ' - What is your github author name?'
-    read -e git_authorname
-    user ' - What is your github author email?'
-    read -e git_authoremail
-
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/gitconfig.local.symlink.example > git/gitconfig.local.symlink
-
-    success 'gitconfig'
+  else
+    info 'skipping git config setup because currently in a non-interactive shell environment'
   fi
 }
 
@@ -130,6 +134,12 @@ install_dotfiles () {
   info 'installing dotfiles'
 
   local overwrite_all=false backup_all=false skip_all=false
+
+  # if in a non-interactive shell then assume we want to backup all existing files
+  if ! [[ -o interactive ]]; then
+    info 'in non-interactive shell: defaulting to "backup_all" existing dotfiles in users home directory'
+    backup_all=true
+  fi
 
   for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink' -not -path '*.git*')
   do

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -141,16 +141,13 @@ install_dotfiles () {
 setup_gitconfig
 install_dotfiles
 
-# If we're on a Mac, let's install and setup homebrew.
-if [ "$(uname -s)" == "Darwin" ]
+# try installing dependencies
+info "installing dependencies"
+if source "$DOTFILES_ROOT"/bin/dot | while read -r data; do info "$data"; done
 then
-  info "installing dependencies"
-  if source bin/dot | while read -r data; do info "$data"; done
-  then
-    success "dependencies installed"
-  else
-    fail "error installing dependencies"
-  fi
+  success "dependencies installed"
+else
+  fail "error installing dependencies"
 fi
 
 echo ''

--- a/terminal_customization/env.zsh
+++ b/terminal_customization/env.zsh
@@ -3,9 +3,14 @@ ZSH_THEME="robbyrussell"
 plugins=(
     git
     macos
-    zsh-syntax-highlighting
-    zsh-autosuggestions
     docker
     docker-compose
 )
+if [[ -e "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}"/plugins/zsh-syntax-highlighting ]]; then
+    plugins=("${plugins[@]}" zsh-syntax-highlighting)
+fi
+if [[ -e "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}"/plugins/zsh-autosuggestions ]]; then
+    plugins=("${plugins[@]}" zsh-autosuggestions)
+fi
+
 source $ZSH/oh-my-zsh.sh

--- a/utilities/env.zsh
+++ b/utilities/env.zsh
@@ -1,3 +1,5 @@
 
 # direnv
-eval "$(direnv hook zsh)"
+if (( $+commands[direnv] )); then
+    eval "$(direnv hook zsh)"
+fi


### PR DESCRIPTION
- bootstrap should always try to install dependencies (since if the dotfiles repo is in a good state it should be portable)
- set defaults for when bootstrap is executed in a non-interactive shell environment (AKA when the repo is automatically installed by codespaces into a devcontainer)
- various fixes