### PR TITLE
Tweaks & Fixes

### DIFF
--- a/python/env.zsh
+++ b/python/env.zsh
@@ -7,5 +7,5 @@ fi
 
 if (( $+commands[pdm] )); then
   # make the Python interpreters aware of PEP 582 packages
-  source =(pdm --pep582)
+  source =(pdm --pep582=zsh)
 fi

--- a/terminal_customization/env.zsh
+++ b/terminal_customization/env.zsh
@@ -6,10 +6,10 @@ plugins=(
     docker
     docker-compose
 )
-if [[ -e "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}"/plugins/zsh-syntax-highlighting ]]; then
+if [[ -e "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting" ]]; then
     plugins=("${plugins[@]}" zsh-syntax-highlighting)
 fi
-if [[ -e "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}"/plugins/zsh-autosuggestions ]]; then
+if [[ -e "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"/plugins/zsh-autosuggestions ]]; then
     plugins=("${plugins[@]}" zsh-autosuggestions)
 fi
 

--- a/terminal_customization/install.sh
+++ b/terminal_customization/install.sh
@@ -9,15 +9,15 @@ if ! [[ -e "$HOME"/.oh-my-zsh ]]; then
 
     plugins=(git osx)
 
-    if ! [[ -e ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting ]]; then
+    if ! [[ -e ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting ]]; then
         echo "Installing zsh-syntax-highlighting"
-        git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}"/plugins/zsh-syntax-highlighting
+        git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"/plugins/zsh-syntax-highlighting
         plugins=("${plugins[@]}" zsh-syntax-highlighting)
     fi
 
-    if ! [[ -e ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions ]]; then
+    if ! [[ -e ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions ]]; then
         echo "Installing zsh-autosuggestions"
-        git clone https://github.com/zsh-users/zsh-autosuggestions.git "${ZSH_CUSTOM:-~/.oh-my-zsh/custom}"/plugins/zsh-autosuggestions
+        git clone https://github.com/zsh-users/zsh-autosuggestions.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"/plugins/zsh-autosuggestions
         plugins=("${plugins[@]}" zsh-autosuggestions)
     fi
 

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # determine dotfiles root by following the symlinked file (syntax dependent on shell and OS)
-if [[ $(basename "${BASH_SOURCE[0]:-$0}") =  "zsh" ]]; then
+if [[ "${BASH_SOURCE[0]:-$0}" = "-zsh" || $(basename "${BASH_SOURCE[0]:-$0}") =  "zsh" ]]; then
   if [[ "$(uname)" = "Darwin" ]]; then
     parentDirectory="$(cd "$( dirname "$( stat -f%Y "${(%):-%N}" )" )" && pwd -P)"
   else


### PR DESCRIPTION
- refactor(pdm): specify shell version
- fix(zsh): account for dynamic dotfiles root dir potentially being returned as '-zsh'
- fix(terminal_customization): change ~ to $HOME so that the plugin paths are properly detected