### PR TITLE
Aws and git

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -26,3 +26,6 @@
         default = simple
 [credential]
 	helper = osxkeychain
+[user]
+	name = avidan-H
+	email = 

--- a/utilities/path.zsh
+++ b/utilities/path.zsh
@@ -1,2 +1,10 @@
 # The next line updates PATH for the Google Cloud SDK.
 if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then . "$HOME/google-cloud-sdk/path.zsh.inc"; fi
+
+
+# set default AWS profile if aws cli is installed and 'development' profile is found
+if (( $+commands[aws] )); then
+    if $(aws configure list-profiles | grep -q "development"); then
+        export AWS_PROFILE=development
+    fi
+fi


### PR DESCRIPTION
- add default user of `avidan-H` to gitconfig (and empty email address)
- set `AWS_PROFILE` default profile to `development` if `aws` cli is installed and `development` profile is found.